### PR TITLE
Replace react-tilt 0.1.4 with react-tilty 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "5.0.1",
-        "react-tilt": "^0.1.4",
+        "react-tilty": "^2.0.3",
         "react-tsparticles": "^2.0.6",
         "serve": "^13.0.2",
         "tachyons": "^4.12.0"
@@ -15480,13 +15480,12 @@
         }
       }
     },
-    "node_modules/react-tilt": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/react-tilt/-/react-tilt-0.1.4.tgz",
-      "integrity": "sha512-bVeRumg+RIn6QN8S92UmubGqX/BG6/QeQISBeAcrS/70dpo/jVj+sjikIawDl5wTuPdubFH8zH0EMulWIctsnw==",
+    "node_modules/react-tilty": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-tilty/-/react-tilty-2.0.3.tgz",
+      "integrity": "sha512-/z23wWNndBpo6bMl5ktVj+Ght1bn+IMjSBIlCn7Fd3Te51MiSU/MRPcyefa6ghK01SxCO0ISf5xaVfTcjdTOag==",
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0-beta || ^16.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0-beta || ^16.0.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-tsparticles": {
@@ -29448,10 +29447,10 @@
         "workbox-webpack-plugin": "^6.4.1"
       }
     },
-    "react-tilt": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/react-tilt/-/react-tilt-0.1.4.tgz",
-      "integrity": "sha512-bVeRumg+RIn6QN8S92UmubGqX/BG6/QeQISBeAcrS/70dpo/jVj+sjikIawDl5wTuPdubFH8zH0EMulWIctsnw==",
+    "react-tilty": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-tilty/-/react-tilty-2.0.3.tgz",
+      "integrity": "sha512-/z23wWNndBpo6bMl5ktVj+Ght1bn+IMjSBIlCn7Fd3Te51MiSU/MRPcyefa6ghK01SxCO0ISf5xaVfTcjdTOag==",
       "requires": {}
     },
     "react-tsparticles": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "5.0.1",
-    "react-tilt": "^0.1.4",
+    "react-tilty": "^2.0.3",
     "react-tsparticles": "^2.0.6",
     "serve": "^13.0.2",
     "tachyons": "^4.12.0"

--- a/src/components/Logo/Logo.js
+++ b/src/components/Logo/Logo.js
@@ -1,4 +1,4 @@
-import Tilt from 'react-tilt';
+import Tilty from 'react-tilty';
 
 import brain from './brain.png';
 import './Logo.css';
@@ -6,11 +6,11 @@ import './Logo.css';
 const Logo = () => {
   return (
     <div className='ma4 mt0'>
-      <Tilt className='Tilt br2 shadow-2' options={{ max: 55 }} style={{ height: 150, width: 150 }}>
+      <Tilty className='Tilt br2 shadow-2' options={{ max: 55 }} style={{ height: 150, width: 150 }}>
         <div className='Tilt-inner pa3'>
           <img style={{ paddingTop: '5px' }} alt='Brain icon by https://icons8.com' src={brain} />
         </div>
-      </Tilt>
+      </Tilty>
     </div>
   );
 };


### PR DESCRIPTION
[react-tilt](https://www.npmjs.com/package/react-tilt) throws npm errors now that React 18 is installed.  [react-tilty](https://www.npmjs.com/package/react-tilty) has been updated more recently and does not lead to npm errors.